### PR TITLE
:sparkles: Add new endpoint to get vehicles; Change on the endpoint n…

### DIFF
--- a/vehicles/serializers.py
+++ b/vehicles/serializers.py
@@ -32,7 +32,7 @@ class VehicleImageSerializer(serializers.ModelSerializer):
         fields = ('id', 'vehicle', 'image')
 
     
-class VehicleSerializer(serializers.ModelSerializer):
+class VehicleDetailsSerializer(serializers.ModelSerializer):
     """
     Serializes Vehicle model data, including comprehensive details like name, description, type, brand,
     and owner. Nested serializers include vehicle images and expenses related to the vehicle.
@@ -48,3 +48,12 @@ class VehicleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Vehicle
         fields = ('id', 'name', 'owner', 'owner_name', 'description', 'type', 'type_name', 'brand', 'year', 'license_plate', 'brand_name', 'expenses', 'images', 'created_at')
+
+        
+class VehicleSerializer(serializers.ModelSerializer):
+    """
+    Serializes Vehicle model data
+    """
+    class Meta:
+        model = Vehicle
+        fields = ('id', 'name')

--- a/vehicles/urls.py
+++ b/vehicles/urls.py
@@ -7,9 +7,10 @@ from .views import *
 
 router = DefaultRouter()
 
-router.register(r'vehicles', VehicleViewSet)
+router.register(r'vehicles-detail', VehicleDetailViewSet)
 router.register(r'types', TypeViewSet)
 router.register(r'brands', BrandViewSet)
 router.register(r'vehicles-images', VehicleImageViewSet)
+router.register(r'vehicles', VehicleViewSet)
 
 urlpatterns = router.urls

--- a/vehicles/views.py
+++ b/vehicles/views.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from .serializers import (
-    TypeSerializer, BrandSerializer, VehicleImageSerializer, VehicleSerializer
+    TypeSerializer, BrandSerializer, VehicleImageSerializer, VehicleDetailsSerializer, VehicleSerializer
 )
 
 from .models import (
@@ -52,7 +52,7 @@ class VehicleImageViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
 
 
-class VehicleViewSet(viewsets.ModelViewSet):
+class VehicleDetailViewSet(viewsets.ModelViewSet):
     """
     A comprehensive viewset managing vehicles, supporting CRUD operations and filtering capabilities.
     Authenticated users can create a vehicle and upload images simultaneously, update vehicle data,
@@ -60,7 +60,7 @@ class VehicleViewSet(viewsets.ModelViewSet):
     """
 
     queryset = Vehicle.objects.all()
-    serializer_class = VehicleSerializer
+    serializer_class = VehicleDetailsSerializer
     permission_classes = [IsAuthenticated]
     filterset_class = VehicleFilter
     
@@ -74,7 +74,7 @@ class VehicleViewSet(viewsets.ModelViewSet):
             for image_file in images:
                 VehicleImage.objects.create(vehicle=vehicle, image=image_file)
                 
-            return Response(VehicleSerializer(vehicle).data, status=status.HTTP_201_CREATED)
+            return Response(VehicleDetailsSerializer(vehicle).data, status=status.HTTP_201_CREATED)
         else:
             return Response(f"Error: {serializer.errors}", status=status.HTTP_400_BAD_REQUEST)
         
@@ -95,6 +95,17 @@ class VehicleViewSet(viewsets.ModelViewSet):
                 for image_file in images:
                     VehicleImage.objects.create(vehicle=updated_vehicle, image=image_file)
 
-            return Response(VehicleSerializer(updated_vehicle).data, status=status.HTTP_200_OK)
+            return Response(VehicleDetailsSerializer(updated_vehicle).data, status=status.HTTP_200_OK)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class VehicleViewSet(viewsets.ModelViewSet):
+    """
+    Get users' vehicles. Only GET request allowed
+    """
+
+    queryset = Vehicle.objects.all()
+    serializer_class = VehicleSerializer
+    permission_classes = [IsAuthenticated]
+    filterset_class = VehicleFilter


### PR DESCRIPTION
This pull request involves significant changes to the vehicle serializers, views, and URLs in the `vehicles` module. The main focus is on distinguishing between detailed and basic vehicle serializers and updating the corresponding viewsets and routes.

Changes to serializers:

* Renamed `VehicleSerializer` to `VehicleDetailsSerializer` and created a new `VehicleSerializer` for basic vehicle data in `vehicles/serializers.py`.

Changes to viewsets:

* Updated `VehicleViewSet` to `VehicleDetailViewSet` for detailed vehicle data and added a new `VehicleViewSet` for basic vehicle data in `vehicles/views.py`. 
* Modified the `create` and `update` methods to use `VehicleDetailsSerializer` for responses in `vehicles/views.py`. 

Changes to URLs:

* Adjusted the URL routes to register `VehicleDetailViewSet` and `VehicleViewSet` separately in `vehicles/urls.py`. 